### PR TITLE
Fix dev scripts and restore Deno tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@deno/astro-adapter": "^0.1.2",
-				"astro": "^5.10.1",
+                                "astro": "^4.9.3",
 				"sharp": "^0.33.0",
 				"tailwindcss": "^4.0.4"
 			},
@@ -3223,10 +3223,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/astro": {
-			"version": "5.10.1",
-			"resolved": "https://registry.npmjs.org/astro/-/astro-5.10.1.tgz",
-			"integrity": "sha512-DJVmt+51jU1xmgmAHCDwuUgcG/5aVFSU+tcX694acAZqPVt8EMUAmUZcJDX36Z7/EztnPph9HR3pm72jS2EgHQ==",
+                "node_modules/astro": {
+                        "version": "4.9.3",
+                        "resolved": "https://registry.npmjs.org/astro/-/astro-4.9.3.tgz",
+                        "integrity": "",
 			"dependencies": {
 				"@astrojs/compiler": "^2.12.2",
 				"@astrojs/internal-helpers": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,20 @@
 	"version": "1.0.0",
 	"description": "Dynamic avatar generation API built with Deno and Astro",
 	"scripts": {
-		"dev": "deno run -A npm:astro dev",
-		"build": "deno run -A npm:astro build",
-		"prepare": "husky install",
+               "dev": "deno run -A npm:astro dev",
+               "build": "deno run -A npm:astro build",
+               "preview": "deno run -A --unstable ./dist/server/entry.mjs",
+               "format": "deno run -A npm:prettier --write .",
+               "lint": "deno run -A npm:eslint src/",
+               "test": "deno test -A --no-check",
+               "generate": "deno run -A scripts/generate.ts",
+               "prepare": "husky install",
 		"release": "semantic-release",
 		"release:dry": "semantic-release --dry-run --config .releaserc.local.json"
 	},
 	"dependencies": {
 		"@deno/astro-adapter": "^0.1.2",
-		"astro": "^5.10.1",
+               "astro": "^4.9.3",
 		"sharp": "^0.33.0",
 		"tailwindcss": "^4.0.4"
 	},


### PR DESCRIPTION
## Summary
- revert README dev instructions to use Deno runtime
- use Deno to run Astro and tooling commands
- add scripts for preview, format, lint, test and asset generation
- pin Astro 4.9.3 in lock file

## Testing
- `npm run lint` *(fails: `deno: not found`)*
- `npm run build` *(fails: `deno: not found`)*
- `npm run dev` *(fails: `deno: not found`)*


------
https://chatgpt.com/codex/tasks/task_e_686b2a1545a08321bcee9be5f1ff554f