### PR TITLE
Implement custom Code component for URL tokens

### DIFF
--- a/src/components/Code.astro
+++ b/src/components/Code.astro
@@ -1,0 +1,16 @@
+---
+import type { HTMLAttributes } from 'astro'
+import { highlightUrl } from './UrlSyntaxHighlighter'
+
+interface Props extends HTMLAttributes<'code'> {
+  code: string
+  wrap?: boolean
+}
+
+const { code, wrap = false, class: className, ...rest } = Astro.props as Props
+const classes = [className, wrap ? 'whitespace-pre-wrap break-words' : '']
+  .filter(Boolean)
+  .join(' ')
+const html = highlightUrl(code)
+---
+<code {...rest} class={classes} set:html={html} />

--- a/src/components/UrlSyntaxHighlighter.ts
+++ b/src/components/UrlSyntaxHighlighter.ts
@@ -1,0 +1,41 @@
+export interface UrlToken {
+    content: string;
+    className: string;
+}
+
+function escapeHtml(str: string): string {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export function tokenizeUrl(url: string): UrlToken[] {
+    try {
+        const p = new URL(url);
+        const tokens: UrlToken[] = [];
+        tokens.push({ content: p.protocol + '//', className: 'url-protocol' });
+        tokens.push({ content: p.hostname, className: 'url-domain' });
+        if (p.pathname) {
+            tokens.push({ content: p.pathname, className: 'url-path' });
+        }
+        if ([...p.searchParams].length > 0) {
+            tokens.push({ content: '?', className: 'url-query' });
+            for (const [key, value] of p.searchParams.entries()) {
+                tokens.push({ content: key, className: 'url-param-key' });
+                tokens.push({ content: '=', className: 'url-query' });
+                tokens.push({ content: value, className: 'url-param-value' });
+            }
+        }
+        return tokens;
+    } catch {
+        return [{ content: url, className: '' }];
+    }
+}
+
+export function highlightUrl(url: string): string {
+    return tokenizeUrl(url)
+        .map((t) =>
+            t.className
+                ? `<span class="${t.className}">${escapeHtml(t.content)}</span>`
+                : escapeHtml(t.content)
+        )
+        .join('');
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { Code } from 'astro:components'
+import Code from '../components/Code.astro'
 import Layout from '../layouts/Layout.astro'
 import { avatarSets, getDefaultAvatarSet } from '../core/domain/AvatarSet'
 import { avatarIds, getDefaultAvatarId } from '../core/domain/AvatarId'
@@ -7,7 +7,6 @@ import { avatarSizes } from '../core/domain/AvatarSize'
 import { avatarFormats, defaultAvatarFormat } from '../core/domain/AvatarFormat'
 import { defaultAvatarText } from '../core/domain/AvatarText'
 import { defaultAvatarColor } from '../core/domain/AvatarColor'
-import { transformers } from './UrlHighlighter'
 
 const defaultParams = {
 	set: getDefaultAvatarSet().toString(),
@@ -154,10 +153,8 @@ const code = `https://exavatar.deno.dev${path}`
 			<Code
 				class='text-sm'
 				code={code}
-				theme='dark-plus'
-				wrap
-				transformers={transformers}
-			/>
+                               wrap
+                       />
 		</p>
 	</main>
 </Layout>


### PR DESCRIPTION
## Summary
- replace the previous Shiki-based Code component
- add `UrlSyntaxHighlighter.ts` to tokenize and color URL parts
- update index page to use the simplified Code component

## Testing
- `deno task format` *(fails: Could not find "prettier" in node_modules)*
- `deno task lint` *(fails: Could not find "eslint" in node_modules)*
- `deno task test` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686dbe0cbb5c8321b087207c88b46221