### PR TITLE
fix: resolve Vercel deployment 500 error and missing imports

### DIFF
--- a/src/core/shared/Environment.ts
+++ b/src/core/shared/Environment.ts
@@ -56,12 +56,24 @@ class EnvironmentManager {
 	}
 
 	private loadConfig(): EnvironmentConfig {
-		const env = process.env.ENV || import.meta.env?.ENV;
+		let env = process.env.ENV || import.meta.env?.ENV;
 
-		if (!env || !Object.values(Environment).includes(env as Environment)) {
-			throw new Error(
-				`Invalid or missing ENV variable. Expected: ${Object.values(Environment).join(', ')}, got: ${env}`,
-			);
+		// Vercel and Node environments commonly use NODE_ENV
+		if (!env) {
+			const nodeEnv = process.env.NODE_ENV || import.meta.env?.NODE_ENV;
+			if (nodeEnv === 'production' || nodeEnv === 'development') {
+				env = nodeEnv;
+			}
+		}
+
+		// Default to production if completely missing in a serverless environment
+		if (!env) {
+			env = Environment.PRODUCTION;
+		}
+
+		if (!Object.values(Environment).includes(env as Environment)) {
+			console.warn(`⚠️ Invalid ENV variable: ${env}. Defaulting to production.`);
+			env = Environment.PRODUCTION;
 		}
 
 		return {

--- a/src/pages/api/avatar.ts
+++ b/src/pages/api/avatar.ts
@@ -31,7 +31,8 @@ export const GET: APIRoute = async ({ request }) => {
 		if (error instanceof ExavatarError) {
 			return new Response(error.message, { status: 400 });
 		}
-		return new Response('Server Error', { status: 500 });
+		console.error('Server error in /api/avatar:', error);
+		return new Response('Server Error: ' + (error instanceof Error ? error.message : String(error)), { status: 500 });
 	}
 };
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,10 @@
 ---
 import { Avatar } from '../core/domain/Avatar';
+import { avatarSets } from '../core/domain/AvatarSet';
+import { avatarIdsMap } from '../core/domain/AvatarId';
+import { avatarSizes } from '../core/domain/AvatarSize';
+import { avatarFormats } from '../core/domain/AvatarFormat';
+import AvatarCode from '../components/AvatarCode.astro';
 import Layout from '../layouts/Layout.astro';
 import Icon from '../components/Icon.astro';
 

--- a/src/pages/playground/index.astro
+++ b/src/pages/playground/index.astro
@@ -1,5 +1,14 @@
 ---
+import { Avatar } from '../../core/domain/Avatar';
+import { avatarSets } from '../../core/domain/AvatarSet';
+import { avatarIdsMap } from '../../core/domain/AvatarId';
+import { avatarSizes } from '../../core/domain/AvatarSize';
+import { avatarFormats } from '../../core/domain/AvatarFormat';
+import AvatarCode from '../../components/AvatarCode.astro';
 import Layout from '../../layouts/Layout.astro';
+import Icon from '../../components/Icon.astro';
+
+const avatar = Avatar.fromUrl(Astro.url);
 ---
 
 <Layout


### PR DESCRIPTION
- Updated `Environment.ts` to properly resolve `NODE_ENV` in Vercel instead of throwing unhandled exceptions if `ENV` isn't strictly defined.
- Added deeper error logging to the `/api/avatar` endpoint for easier debugging on serverless environments.
- Restored UI component imports in `index.astro` and `playground/index.astro` that were accidentally removed.