### PR TITLE
fix: force production environment on Vercel deployments

### DIFF
--- a/src/core/shared/Environment.ts
+++ b/src/core/shared/Environment.ts
@@ -66,6 +66,11 @@ class EnvironmentManager {
 			}
 		}
 
+		// Force VERCEL env to production
+		if (process.env.VERCEL) {
+			env = Environment.PRODUCTION;
+		}
+
 		// Default to production if completely missing in a serverless environment
 		if (!env) {
 			env = Environment.PRODUCTION;


### PR DESCRIPTION
- Updated `EnvironmentManager` to explicitly check for the `process.env.VERCEL` variable.
- Forcing `Environment.PRODUCTION` guarantees the application uses the `GitHubAvatarRepository` on Vercel, bypassing the `ENOENT` error triggered when `LocalAvatarRepository` attempts to access missing local generated avatar files in a serverless context.